### PR TITLE
👷  Consistent label name with spylib

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,6 +1,6 @@
 {
     "LABEL":{
-       "name":"Title need formatting",
+       "name":"Gitmoji missing",
        "color":"EEEEEE"
     },
     "CHECKS": {


### PR DESCRIPTION
Want to make sure we have the same label across all the repos that have pr-title-checker enabled 