### PR TITLE
:bug: Fix typo in bash variable assignment

### DIFF
--- a/test_suite.sh
+++ b/test_suite.sh
@@ -35,7 +35,7 @@ then
   MYPY_REPORTS="--junit-xml ${REPORTS_FOLDER}typing.xml"
   if [ -f ./coverage.conf ];
   then
-    $covconf="--cov-config ./coverage.conf"
+    covconf="--cov-config ./coverage.conf"
   fi
   PYTEST_REPORTS="--junitxml ${REPORTS_FOLDER}unittesting.xml $covconf --cov-report xml:${REPORTS_FOLDER}coverage.xml"
 fi


### PR DESCRIPTION
This simple typo meant that `--cov-config ./coverage.conf` was executed as a program instead of going in the variable as a string. Not cool!

I will push this through with admin level permissions cause it's a simple 1 character fix.
I tested it and it is now working properly.