### PR TITLE
:bug: Fix typo in bash variable assignment (#365)

### DIFF
--- a/test_suite.sh
+++ b/test_suite.sh
@@ -35,7 +35,7 @@ then
   MYPY_REPORTS="--junit-xml ${REPORTS_FOLDER}typing.xml"
   if [ -f ./coverage.conf ];
   then
-    $covconf="--cov-config ./coverage.conf"
+    covconf="--cov-config ./coverage.conf"
   fi
   PYTEST_REPORTS="--junitxml ${REPORTS_FOLDER}unittesting.xml $covconf --cov-report xml:${REPORTS_FOLDER}coverage.xml"
 fi


### PR DESCRIPTION
Backporting this fix to the main branch. Simple one but an important one.